### PR TITLE
refactor: use new `key-close` DDS event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # close-and-restore-tab.yazi
 
-A [Yazi](https://github.com/sxyazi/yazi) plugin that adds the functionality to close and restore tab.
+A [Yazi](https://github.com/sxyazi/yazi) plugin that adds the functionality to restore closed tabs.
 
 ## Features
 
- - Close the tab, and go to the left/right tab
- - Restore the closed tab to its previous position
+- Remember a tab's working directory and position when it is closed.
+- Restore any closed tab at its previous position.
 
 ## Installation
 
@@ -29,19 +29,17 @@ Add this to your `keymap.toml`:
 
 ```toml
 [[manager.prepend_keymap]]
-on = [ "<C-w>" ]
-run = "plugin close-and-restore-tab close_to_left"
-desc = "Close the current tab and turn to left tab, or quit if it is last tab"
-
-[[manager.prepend_keymap]]
-on = [ "<C-w>" ]
-run = "plugin close-and-restore-tab close_to_right"
-desc = "Close the current tab and turn to right tab, or quit if it is last tab"
-
-[[manager.prepend_keymap]]
 on = [ "<C-t>" ]
 run = "plugin close-and-restore-tab restore"
-desc = "Restore the closed tab"
+desc = "Restore the previously closed tab"
 ```
 
-`close_to_left` and `close_to_right` respectively mean switching to the left/right tab after closing the tab. Please choose the one you like.
+If you want to use a non-default binding to close the current tab,
+which is bound to `<C-c>`:
+
+```toml
+[[mgr.prepend_keymap]]
+on = "<C-w>"
+run = "close"
+desc = "Close the current tab, or quit if it is the last tab"
+```

--- a/main.lua
+++ b/main.lua
@@ -10,10 +10,12 @@ local _save_closed_tab = ya.sync(function(state)
     local closed_tabs = _get_closed_tabs()
 
     -- TODO: add more tab properties
-    closed_tabs[#closed_tabs + 1] = {
+    local tab = {
         idx = tonumber(cx.tabs.idx) - 1,
         cwd = tostring(cx.active.current.cwd),
     }
+    closed_tabs[#closed_tabs + 1] = tab
+    ya.dbg("Recorded closed tab", tab)
 
     state.closed_tabs = closed_tabs
 end)
@@ -30,6 +32,7 @@ local restore = ya.sync(function(state)
     end
 
     local tab = closed_tabs[#closed_tabs]
+    ya.dbg("Restoring tab", tab)
     table.remove(closed_tabs, #closed_tabs)
     state.closed_tabs = closed_tabs
 

--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,4 @@
---- @since 26.2.3
+--- @since 26.5.1
 
 -- Requires `key-close` event from https://github.com/sxyazi/yazi/commit/740d8919896542de18db0c5da5fb347a14459890.
 

--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,7 @@
 -- Requires `key-close` event from https://github.com/sxyazi/yazi/commit/740d8919896542de18db0c5da5fb347a14459890.
 
 local _get_closed_tabs = ya.sync(function(state)
-    return not state.closed_tabs and {} or state.closed_tabs
+    return state.closed_tabs or {}
 end)
 
 local _save_closed_tab = ya.sync(function(state)

--- a/main.lua
+++ b/main.lua
@@ -21,7 +21,11 @@ end)
 local restore = ya.sync(function(state)
     local closed_tabs = _get_closed_tabs()
     if #closed_tabs == 0 then
-        ya.info("No more tabs to restore")
+        ya.notify {
+            title = "No tabs!",
+            content = "No more tabs to restore",
+            timeout = 4,
+        }
         return
     end
 

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,7 @@
+--- @since 26.2.3
+
+-- Requires `key-close` event from https://github.com/sxyazi/yazi/commit/740d8919896542de18db0c5da5fb347a14459890.
+
 local _get_closed_tabs = ya.sync(function(state)
     return not state.closed_tabs and {} or state.closed_tabs
 end)
@@ -14,37 +18,10 @@ local _save_closed_tab = ya.sync(function(state)
     state.closed_tabs = closed_tabs
 end)
 
-local _close_and_switch = ya.sync(function(state, idx)
-    ya.emit("close", {})
-    ya.emit("tab_switch", { idx })
-end)
-
-local close_to_left = ya.sync(function(state)
-    local active_idx = tonumber(cx.tabs.idx) - 1
-    local target_idx = active_idx - 1
-    if active_idx == 0 then
-        target_idx = 0
-    end
-
-    _save_closed_tab()
-    _close_and_switch(target_idx)
-end)
-
-local close_to_right = ya.sync(function(state)
-    local total_tabs = #cx.tabs
-    local active_idx = tonumber(cx.tabs.idx) - 1
-    local target_idx = active_idx
-    if active_idx == total_tabs - 1 then
-        target_idx = total_tabs - 2
-    end
-
-    _save_closed_tab()
-    _close_and_switch(target_idx)
-end)
-
 local restore = ya.sync(function(state)
     local closed_tabs = _get_closed_tabs()
     if #closed_tabs == 0 then
+        ya.info("No more tabs to restore")
         return
     end
 
@@ -68,21 +45,17 @@ local restore = ya.sync(function(state)
 end)
 
 return {
+    setup = function()
+        ps.sub("key-close", function(args)
+            if #cx.tabs ~= 1 then
+                _save_closed_tab()
+            end
+            return args
+        end)
+    end,
+
     entry = function(_, job)
         local action = job.args[1]
-        if not action then
-            return
-        end
-
-        if action == "close_to_left" then
-            close_to_left()
-            return
-        end
-
-        if action == "close_to_right" then
-            close_to_right()
-            return
-        end
 
         if action == "restore" then
             restore()


### PR DESCRIPTION
Requires yazi 26.2.3 (not yet released, not even nightly).

Using this event means we do not cause a transient notification due to a plugin task still being run in the background when yazi wants to exit as a result of the emitted `close` event.

Additionally, functionality to choose which view will be opened after the view is closed as been removed as well because it made the code much more complicated and due to the new event-based life-cycle this can be easily implemented by a separate plugin, independent of the restoration functionality provided by this plugin.

Closes #4

---

With this scope change, one could argue that the plugin might better be renamed to just "restore-tab" since it does not handle closing anymore, but I'll leave that for you to decide.